### PR TITLE
Setting Up NULL-LS

### DIFF
--- a/private_dot_config/nvim/dot_luarc.json
+++ b/private_dot_config/nvim/dot_luarc.json
@@ -1,0 +1,5 @@
+{
+    "diagnostics.globals": [
+        "vim"
+    ]
+}

--- a/private_dot_config/nvim/lua/dot_stylua.toml
+++ b/private_dot_config/nvim/lua/dot_stylua.toml
@@ -1,0 +1,2 @@
+indent_type = "Spaces"
+indent_width = 2

--- a/private_dot_config/nvim/lua/plugins/none-ls.lua
+++ b/private_dot_config/nvim/lua/plugins/none-ls.lua
@@ -1,0 +1,11 @@
+return {
+  "nvimtools/none-ls.nvim",
+  config = function()
+    local null_ls = require("null-ls")
+    null_ls.setup({
+      sources = {
+        null_ls.builtins.formatting.stylua
+      }
+    })
+  end
+}

--- a/private_dot_config/nvim/lua/plugins/none-ls.lua
+++ b/private_dot_config/nvim/lua/plugins/none-ls.lua
@@ -4,8 +4,10 @@ return {
     local null_ls = require("null-ls")
     null_ls.setup({
       sources = {
-        null_ls.builtins.formatting.stylua
-      }
+        null_ls.builtins.formatting.stylua,
+      },
     })
-  end
+
+    vim.keymap.set("n", "<leader>gf", vim.lsp.buf.format, {})
+  end,
 }

--- a/private_dot_config/nvim/lua/plugins/none-ls.lua
+++ b/private_dot_config/nvim/lua/plugins/none-ls.lua
@@ -1,13 +1,18 @@
 return {
-  "nvimtools/none-ls.nvim",
-  config = function()
-    local null_ls = require("null-ls")
-    null_ls.setup({
-      sources = {
-        null_ls.builtins.formatting.stylua,
-      },
-    })
+	"nvimtools/none-ls.nvim",
+	dependencies = {
+		"nvimtools/none-ls-extras.nvim",
+	},
+	config = function()
+		local null_ls = require("null-ls")
+		null_ls.setup({
+			sources = {
+				null_ls.builtins.formatting.stylua,
+				null_ls.builtins.formatting.prettier,
+				require("none-ls.diagnostics.eslint_d"),
+			},
+		})
 
-    vim.keymap.set("n", "<leader>gf", vim.lsp.buf.format, {})
-  end,
+		vim.keymap.set("n", "<leader>gf", vim.lsp.buf.format, {})
+	end,
 }

--- a/private_dot_config/nvim/lua/plugins/none-ls.lua
+++ b/private_dot_config/nvim/lua/plugins/none-ls.lua
@@ -1,18 +1,18 @@
 return {
-	"nvimtools/none-ls.nvim",
-	dependencies = {
-		"nvimtools/none-ls-extras.nvim",
-	},
-	config = function()
-		local null_ls = require("null-ls")
-		null_ls.setup({
-			sources = {
-				null_ls.builtins.formatting.stylua,
-				null_ls.builtins.formatting.prettier,
-				require("none-ls.diagnostics.eslint_d"),
-			},
-		})
+  "nvimtools/none-ls.nvim",
+  dependencies = {
+    "nvimtools/none-ls-extras.nvim",
+  },
+  config = function()
+    local null_ls = require("null-ls")
+    null_ls.setup({
+      sources = {
+        null_ls.builtins.formatting.stylua,
+        null_ls.builtins.formatting.prettier,
+        require("none-ls.diagnostics.eslint_d"),
+      },
+    })
 
-		vim.keymap.set("n", "<leader>gf", vim.lsp.buf.format, {})
-	end,
+    vim.keymap.set("n", "<leader>gf", vim.lsp.buf.format, {})
+  end,
 }


### PR DESCRIPTION
This PR sets up [`NULL-LS`](https://github.com/nvimtools/none-ls.nvim) in Neovim to enable _formatters_ and _linters_ for a smoother development experience. The following tools are configured: [StyLua](https://github.com/JohnnyMorganz/StyLua) for Lua Files, and Prettier/ ESLint for TS/JS files. A keymap is configured to apply the linter and formatter.

**Video Reference:** [What the hell is NULL-LS](https://www.youtube.com/watch?v=SxuwQJ0JHMU&list=PLsz00TDipIffreIaUNk64KxTIkQaGguqn&index=4)
