### PR TITLE
Password Manager Support

### DIFF
--- a/.chezmoi.toml.tmpl
+++ b/.chezmoi.toml.tmpl
@@ -1,4 +1,6 @@
 {{- $isWorkComputer := promptBoolOnce . "isWorkComputer" "Is this your work computer" -}}
 
+[hooks.read-source-state.pre]
+    command = ".local/share/chezmoi/.install-password-manager.sh"
 [data]
     isWorkComputer = {{ $isWorkComputer }}

--- a/.install-password-manager.sh
+++ b/.install-password-manager.sh
@@ -3,6 +3,7 @@
 # exit immediately if password-manager-binary is already in $PATH
 type pass >/dev/null 2>&1 && exit
 
+# install password manager
 case "$(uname -s)" in
 Linux)
   sudo apt install pass
@@ -12,3 +13,7 @@ Linux)
   exit 1
   ;;
 esac
+
+# init password store repository
+git clone git@github.com:ThomasCode92/password-store.git .password-store
+pass init $PASS_GPG_KEY

--- a/.install-password-manager.sh
+++ b/.install-password-manager.sh
@@ -1,0 +1,14 @@
+#!/bin/sh
+
+# exit immediately if password-manager-binary is already in $PATH
+type pass >/dev/null 2>&1 && exit
+
+case "$(uname -s)" in
+Linux)
+  sudo apt install pass
+  ;;
+*)
+  echo "unsupported OS"
+  exit 1
+  ;;
+esac

--- a/README.md
+++ b/README.md
@@ -30,7 +30,8 @@ rustup update
 
 #### Password Manager Setup 🔐🗝️
 
-Create a folder `backup-keys` in the home directory to store GPG keys. Past the private and public keys as `private-key.asc` and `public-key.asc`, respectively. Then, import these keys into the GPG keyring with the following commands:
+A _password manager_, called [`pass`](https://www.passwordstore.org/), will be used to manage encrypted passwords and API keys. These will be stored in a local directory at `~/.password-store`. The password store will be initialized during `chezmoi init`, but GPG keys must be imported beforehand.
+To handle GPG keys, create a `backup-keys` folder in the directory. Save the private and public keys as `private-key.asc` and `public-key.asc`, respectively. Then, import the keys into your GPG keyring using the following commands:
 
 ```bash
 # Import GPG keys

--- a/README.md
+++ b/README.md
@@ -28,6 +28,22 @@ curl --proto '=https' --tlsv1.2 -sSf https://sh.rustup.rs | sh
 rustup update
 ```
 
+#### Password Manager Setup 🔐🗝️
+
+Create a folder `backup-keys` in the home directory to store GPG keys. Past the private and public keys as `private-key.asc` and `public-key.asc`, respectively. Then, import these keys into the GPG keyring with the following commands:
+
+```bash
+# Import GPG keys
+gpg --import ~/backup-keys/private-key.asc
+gpg --import ~/backup-keys/public-key.asc
+
+# Export the key ID for initial setup
+gpg -K  # Locate and copy the key ID for password management
+export PASS_GPG_KEY=<PASS_GPG_KEY>
+```
+
+Replace `<PASS_GPG_KEY>` with the actual key ID copied from the previous command.
+
 ### Syncing Dotfiles with Chezmoi 🔄📁
 
 ```bash

--- a/private_dot_config/fish/config.fish
+++ b/private_dot_config/fish/config.fish
@@ -15,6 +15,7 @@ source ~/.asdf/asdf.fish
 export PATH="~/.local/bin:$PATH"
 export EDITOR=nvim
 export VISUAL=nvim
+set -x OPENAI_API_KEY (pass show openai/api_key | head -n 1)
 
 # --- aliases ---
 alias ls="eza --color=always --long --git --no-filesize --icons=always --no-time --no-user --no-permissions"

--- a/scripts/executable_gpg-backup.sh
+++ b/scripts/executable_gpg-backup.sh
@@ -1,0 +1,76 @@
+#!/bin/bash
+
+# GPG Backup & Restore Script
+
+BACKUP_DIR="gpg-backup"
+TIMESTAMP=$(date +"%Y-%m-%d_%H-%M-%S")
+
+backup_gpg() {
+    echo "🔒 Starting GPG key backup..."
+    mkdir -p "$BACKUP_DIR/$TIMESTAMP"
+    
+    echo "🔑 Listing secret keys..."
+    gpg --list-secret-keys --keyid-format LONG
+    
+    read -p "Enter the Key ID to backup (or 'all' for every key): " KEY_ID
+    if [[ "$KEY_ID" == "all" ]]; then
+        gpg --export --armor > "$BACKUP_DIR/$TIMESTAMP/all-public-keys.asc"
+        gpg --export-secret-keys --armor > "$BACKUP_DIR/$TIMESTAMP/all-private-keys.asc"
+    else
+        gpg --export --armor "$KEY_ID" > "$BACKUP_DIR/$TIMESTAMP/public-key-$KEY_ID.asc"
+        gpg --export-secret-keys --armor "$KEY_ID" > "$BACKUP_DIR/$TIMESTAMP/private-key-$KEY_ID.asc"
+    fi
+    
+    echo "📂 Backing up ownertrust..."
+    gpg --export-ownertrust > "$BACKUP_DIR/$TIMESTAMP/ownertrust.txt"
+    
+    echo "📂 Copying GPG config..."
+    cp -r ~/.gnupg "$BACKUP_DIR/$TIMESTAMP/gnupg-config"
+    
+    echo "✅ Backup completed! Files saved in: $BACKUP_DIR/$TIMESTAMP"
+}
+
+restore_gpg() {
+    echo "🔓 Starting GPG key restore..."
+    read -p "Enter the backup folder path: " RESTORE_PATH
+    
+    if [[ ! -d "$RESTORE_PATH" ]]; then
+        echo "❌ Invalid path. Exiting."
+        exit 1
+    fi
+    
+    echo "🔑 Importing keys..."
+    gpg --import "$RESTORE_PATH"/*.asc
+    
+    echo "📂 Restoring GPG config..."
+    cp -r "$RESTORE_PATH/gnupg-config" ~/.gnupg
+
+    echo "🛡️  Restoring ownertrust..."
+    gpg --import-ownertrust "$RESTORE_PATH/ownertrust.txt"
+    
+    echo "🔧 Fixing permissions..."
+    chmod 700 ~/.gnupg
+    chmod 600 ~/.gnupg/*
+    
+    echo "✅ Restore completed! Check your keys with: gpg --list-keys"
+}
+
+
+echo "GPG Backup & Restore Script"
+echo "1. Backup GPG Keys"
+echo "2. Restore GPG Keys"
+read -p "Choose an option (1 or 2): " CHOICE
+
+case $CHOICE in
+    1)
+        backup_gpg
+        ;;
+    2)
+        restore_gpg
+        ;;
+    *)
+        echo "❌ Invalid option. Exiting."
+        ;;
+esac
+
+exit 0


### PR DESCRIPTION
This PR adds support for using '_pass_' as the system's password manager. It also includes a script for managing GPG key backups. As a test, the OpenAI key is exported in the Fish configuration. For more details, see the README.md.

## References
* **pass** - [official documentation](https://www.passwordstore.org/)
* Installation with '_chezmoi_' - [official docs](https://www.chezmoi.io/user-guide/advanced/install-your-password-manager-on-init/)